### PR TITLE
Test new features

### DIFF
--- a/canvas-mods/accounts/home-courses-search/feature-enhance-search-form/README.md
+++ b/canvas-mods/accounts/home-courses-search/feature-enhance-search-form/README.md
@@ -1,3 +1,5 @@
 # Enhance Search Form
 
-This feature improves the search form for the courses. This fills the extra space after the blueprint button to avoid the extra blank space being treated as part of the button. This also adds options to search by published state and to sort by the Canvas course ID.  Sorting by the Canvas course ID can help with finding the most recently created courses.
+This feature improves the search form for the courses. This adds options to search by published state and to sort by the Canvas course ID. Sorting by the Canvas course ID can help with finding the most recently created courses.
+
+[DEPRECATED FEATURE] This fills the extra space after the blueprint button to avoid the extra blank space being treated as part of the button.

--- a/canvas-mods/accounts/home-courses-search/feature-enhance-search-form/enhance-search-form-courses.js
+++ b/canvas-mods/accounts/home-courses-search/feature-enhance-search-form/enhance-search-form-courses.js
@@ -7,7 +7,7 @@
         adminCoursesPeopleLink: true,
         adminCoursesSubaccountLink: true,
         adminCoursesGradesButton: true,
-        adminCoursesBlueprintInputPreventFill: true,
+        adminCoursesBlueprintInputPreventFill: false,
         adminCoursesAdditionalSearchInputs: true,
       },
       async function (items) {
@@ -69,11 +69,21 @@
     const rowOfSearchOptions = document.querySelector(
       "div#content form > span > span > span > span > span:nth-child(2)"
     );
-    if (rowOfSearchOptions) {
-      rowOfSearchOptions.insertAdjacentHTML(
+    const searchForm = document.querySelector("div#content form");
+    const additionalSearchWrapper = document.querySelector(
+      "div#content form div.ski-additional-search-options"
+    );
+    if (searchForm && !additionalSearchWrapper) {
+      const wrapper = document.createElement("div");
+      wrapper.classList.add("ski-additional-search-options");
+      wrapper.style.display = "flex";
+      wrapper.style.justifyContent = "space-between";
+      wrapper.style.marginTop = "1rem";
+
+      wrapper.insertAdjacentHTML(
         "afterbegin",
         `
-        <div class="ic-Form-control" style="max-width: 20rem; padding-left: 0.375rem; padding-right: 0.375rem;">
+        <div class="ic-Form-control" style="display: inline-block; max-width: 20rem; padding-right: 0.375rem;">
           <select id="ski-course-search-state-select" class="ic-Input">
             <optgroup label="Select course state">
               <option value="">All Course States</option>
@@ -85,15 +95,15 @@
       `
       );
 
-      const searchForm = document.querySelector("div#content form");
-      searchForm.insertAdjacentHTML(
-        "afterend",
+      wrapper.insertAdjacentHTML(
+        "beforeend",
         `
-        <div style="text-align: right;">
+        <div>
           <button data-sort="" id="ski-course-search-course-id-sort-btn" class="Button">Sort by Course ID - Descending</button>
         </div>
       `
       );
+      searchForm.appendChild(wrapper);
 
       const url = new URL(window.location);
       const stateSelect = document.getElementById(

--- a/canvas-mods/accounts/home-courses-search/feature-enhance-search-results/README.md
+++ b/canvas-mods/accounts/home-courses-search/feature-enhance-search-results/README.md
@@ -1,3 +1,5 @@
 # Enhance Search Results
 
-This feature makes improvements to the data in the rows for the course search results. It adds the course code below the course name. It adds quick links to the People page and gradebook for a course.  It adds a locked icon for concluded courses. It adds a link to the sub-account if the admin has admin access to that sub-account.
+This feature makes improvements to the data in the rows for the course search results. It adds the course code below the course name. It adds quick links to the People page and gradebook for a course. It adds a locked icon for concluded courses.
+
+[DEPRECATED FEATURE] It adds a link to the sub-account if the admin has admin access to that sub-account.

--- a/canvas-mods/accounts/home-courses-search/feature-enhance-search-results/enhance-search-results-courses.js
+++ b/canvas-mods/accounts/home-courses-search/feature-enhance-search-results/enhance-search-results-courses.js
@@ -5,9 +5,8 @@
         adminCoursesConcludedIcon: true,
         adminCoursesCourseCode: true,
         adminCoursesPeopleLink: true,
-        adminCoursesSubaccountLink: true,
+        adminCoursesSubaccountLink: false,
         adminCoursesGradesButton: true,
-        adminCoursesBlueprintInputPreventFill: true,
         adminCoursesAdditionalSearchInputs: true,
       },
       async function (items) {
@@ -344,15 +343,23 @@
             numOfStudentsTd.innerHTML = `<a href='/courses/${course["id"]}/users' target='_blank' title='View People in course' class="ski-course-people"'>${numOfStudentsTd.innerText}</a>`;
           }
         }
-        if (addViewGradesButton) {
-          if (!numOfStudentsTd.querySelector("a.ski-course-view-grades")) {
-            numOfStudentsTd.innerHTML += `
-              <br><br>
-              <a href='/courses/${course["id"]}/gradebook' target='_blank' title='View course gradebook' class='ski-course-view-grades Button' style="background: white; margin: 0px; padding: 0.4rem; border-radius: 0.25rem; border-width: 0px; width: auto; cursor: pointer;">
-                <i class="icon-line icon-gradebook" aria-hidden="true"></i>
-              </a>
-            `;
-          }
+      }
+    }
+    if (addViewGradesButton) {
+      const gradeLink = row.querySelector("td a.ski-course-view-grades");
+      if (!gradeLink) {
+        const numOfStudentsTd = row.querySelector("td:nth-last-child(2)");
+        numOfStudentsTd.style.textAlign = "center";
+        if (
+          numOfStudentsTd &&
+          !numOfStudentsTd.querySelector("a.ski-course-view-grades")
+        ) {
+          numOfStudentsTd.innerHTML += `
+            <br><br>
+            <a href='/courses/${course["id"]}/gradebook' target='_blank' title='View course gradebook' class='ski-course-view-grades Button' style="background: white; margin: 0px; padding: 0.4rem; border-radius: 0.25rem; border-width: 0px; width: auto; cursor: pointer;">
+              <i class="icon-line icon-gradebook" aria-hidden="true"></i>
+            </a>
+          `;
         }
       }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Canvas LMS Mods (Basic)",
   "description": "This provides modifications to the Canvas LMS to improve the user experience visually and functionally.",
-  "version": "5.3.2",
-  "version_name": "5.3.2",
+  "version": "5.3.3",
+  "version_name": "5.3.3",
   "manifest_version": 3,
   "permissions": ["storage"],
   "host_permissions": [

--- a/options.css
+++ b/options.css
@@ -10,6 +10,7 @@ details {
   border: 1px solid #aaa;
   border-radius: 4px;
   padding: .5em .5em 0;
+  margin-bottom: 0.5rem;
 }
 
 summary {
@@ -25,4 +26,8 @@ details[open] {
 details[open] summary {
   border-bottom: 1px solid #aaa;
   margin-bottom: .5em;
+}
+
+button#save {
+  margin-top: 1rem;
 }

--- a/options.html
+++ b/options.html
@@ -9,6 +9,17 @@
   <body>
     <h1>Enable/Disable Features and Customize Default Settings</h1>
 
+    <p>
+      Learn more about the available features at the
+      <a
+        href="https://code-with-ski.github.io/Canvas-LMS_Mods-Website/"
+        target="_blank"
+        rel="noopener"
+        >Canvas LMS Mods</a
+      >
+      website.
+    </p>
+
     <details>
       <summary>Global Customizations</summary>
       <label>
@@ -267,10 +278,9 @@
           <input
             type="checkbox"
             id="admin-courses-blueprint-input-prevent-fill"
-            checked
           />
-          Prevent "Show only blueprint courses" input from stretching to fill
-          empty space
+          [DEPRECATED] Prevent "Show only blueprint courses" input from
+          stretching to fill empty space
         </label>
         <label>
           <input
@@ -291,9 +301,10 @@
           concluded
         </label>
         <label>
-          <input type="checkbox" id="admin-courses-subaccount-link" checked />
-          Convert subaccount name in search results to link to the course search
-          for that subaccount (*Requires manage account settings permission)
+          <input type="checkbox" id="admin-courses-subaccount-link" />
+          [DEPRECATED] Convert subaccount name in search results to link to the
+          course search for that subaccount (*Requires manage account settings
+          permission)
         </label>
         <label>
           <input type="checkbox" id="admin-courses-people-link" checked />

--- a/options.js
+++ b/options.js
@@ -296,8 +296,8 @@ function saveOptions() {
         isRubricUsedForGradingIndicatorEnabled,
       courseDiscussionExportGrades: isDiscussionGradeExportEnabled,
       courseSectionsSectionReport: enableSectionsReports,
-      adminCoursesBlueprintInputPreventFill: isBlueprintInputFillPrevent,
-      adminCoursesSubaccountLink: isAdminCoursesSubaccountLinkEnabled,
+      adminCoursesBlueprintInputPreventFill: isBlueprintInputFillPrevent, // [DEPRECATED]
+      adminCoursesSubaccountLink: isAdminCoursesSubaccountLinkEnabled, // [DEPRECATED]
       adminCoursesConcludedIcon: isCourseConcludedIconEnabled,
       adminCoursesPeopleLink: isPeopleLinkEnabled,
       adminCoursesCourseCode: isCourseCodeEnabled,
@@ -380,11 +380,11 @@ function restoreOptions() {
       courseAssignmentRubricUsedForGradingCheck: true,
       courseDiscussionExportGrades: true,
       courseSectionsSectionReport: true,
-      adminCoursesBlueprintInputPreventFill: true,
+      adminCoursesBlueprintInputPreventFill: false, // [DEPRECATED]
       adminCoursesAdditionalSearchInputs: true,
       adminCoursesCourseCode: true,
       adminCoursesConcludedIcon: true,
-      adminCoursesSubaccountLink: true,
+      adminCoursesSubaccountLink: false, // [DEPRECATED]
       adminCoursesPeopleLink: true,
       adminCoursesGradesButton: true,
       adminUsersEnrollmentsResizable: true,


### PR DESCRIPTION
- Deprecated feature adjusting the style on the only blueprint courses checkbox on the admin courses search due to additional search option added by Instructure
- Deprecated feature for converting the sub-account name in the admin courses search since this is now a native feature
- Updated placement of additional search options on the admin course search to be in their own row to improve the appearance
- Updated browser search options to add a link to the documentation website and improve spacing
- Fixed feature for adding link to grades in the admin course search to not require enabling the number of students to be a link to the People page in the course