### PR TITLE
Send Accept: application/json on remaining API fetches (fixes while(1); JSON errors)

### DIFF
--- a/canvas-mods/accounts/home-courses-search/feature-enhance-search-results/enhance-search-results-courses.js
+++ b/canvas-mods/accounts/home-courses-search/feature-enhance-search-results/enhance-search-results-courses.js
@@ -70,7 +70,7 @@
     }
     url.searchParams.append("include[]", "ui_invoked");
     url.searchParams.append("teacher_limit", 25);
-    return fetch(url)
+    return fetch(url, { headers: { Accept: "application/json" } })
       .then((response) => {
         return response.json();
       })
@@ -91,7 +91,7 @@
     const url = new URL(
       `${window.location.protocol}//${window.location.hostname}/api/v1${window.location.pathname}/courses/${courseId}`
     );
-    return fetch(url)
+    return fetch(url, { headers: { Accept: "application/json" } })
       .then((response) => {
         return response.json();
       })
@@ -109,7 +109,7 @@
     const url = new URL(
       `${window.location.protocol}//${window.location.hostname}/api/v1/accounts/self/permissions`
     );
-    return fetch(url)
+    return fetch(url, { headers: { Accept: "application/json" } })
       .then((response) => {
         return response.json();
       })

--- a/canvas-mods/accounts/sis_import/feature-sis-import-log/sis-import-log.js
+++ b/canvas-mods/accounts/sis_import/feature-sis-import-log/sis-import-log.js
@@ -249,16 +249,19 @@
 
     let fetches = [];
     fetches.push(
-      fetch(url)
+      fetch(url, { headers: { Accept: "application/json" } })
         .then(response => {
+          let nextUrl;
           let links = response.headers.get("link");
-          links = links.replaceAll("<", "").replaceAll(">", "").replaceAll(" rel=", "").replaceAll('"', "");
-          links = links.split(",");
-          links = links.map(link => link.split(";"));
-          const linkDictionary = {};
-          links.forEach(link => linkDictionary[link[1]] = link[0]);
+          if (links) {
+            links = links.replaceAll("<", "").replaceAll(">", "").replaceAll(" rel=", "").replaceAll('"', "");
+            links = links.split(",");
+            links = links.map(link => link.split(";"));
+            const linkDictionary = {};
+            links.forEach(link => linkDictionary[link[1]] = link[0]);
 
-          const nextUrl = linkDictionary["next"];
+            nextUrl = linkDictionary["next"];
+          }
           if (nextUrl) {
             nextButton.dataset.url = nextUrl;
             nextButton.disabled = false;

--- a/canvas-mods/accounts/sub_accounts/feature-show-ids/show-ids-sub-accounts.js
+++ b/canvas-mods/accounts/sub_accounts/feature-show-ids/show-ids-sub-accounts.js
@@ -94,7 +94,7 @@
     );
     await new Promise((r) => setTimeout(r, requestNum * 10));
     const baseUrl = `${window.location.protocol}//${window.location.hostname}`;
-    fetch(`${baseUrl}/api/v1/accounts/${canvasId}`)
+    fetch(`${baseUrl}/api/v1/accounts/${canvasId}`, { headers: { Accept: "application/json" } })
       .then((response) => response.json())
       .then((data) => {
         let sisId = data["sis_account_id"];

--- a/canvas-mods/shared-locations/global/feature-admin-quick-access/feature-admin-quick-access-global-nav.js
+++ b/canvas-mods/shared-locations/global/feature-admin-quick-access/feature-admin-quick-access-global-nav.js
@@ -257,9 +257,12 @@
 
   function getPermissions(accountId = "self") {
     let userPermissions = {};
+    if (!accountId) {
+      accountId = "self";
+    }
     const baseUrl = `${window.location.protocol}//${window.location.hostname}`;
     const url = `${baseUrl}/api/v1/accounts/${accountId}/permissions`;
-    return fetch(url)
+    return fetch(url, { headers: { Accept: "application/json" } })
       .then((response) => {
         return response.json();
       })
@@ -683,20 +686,22 @@
 
   function paginatedRequest(url, results, keyForArray) {
     let nextUrl = "";
-    return fetch(url)
+    return fetch(url, { headers: { Accept: "application/json" } })
       .then((response) => {
         let links = response.headers.get("link");
-        links = links
-          .replaceAll("<", "")
-          .replaceAll(">", "")
-          .replaceAll(" rel=", "")
-          .replaceAll('"', "");
-        links = links.split(",");
-        links = links.map((link) => link.split(";"));
-        const linkDictionary = {};
-        links.forEach((link) => (linkDictionary[link[1]] = link[0]));
+        if (links) {
+          links = links
+            .replaceAll("<", "")
+            .replaceAll(">", "")
+            .replaceAll(" rel=", "")
+            .replaceAll('"', "");
+          links = links.split(",");
+          links = links.map((link) => link.split(";"));
+          const linkDictionary = {};
+          links.forEach((link) => (linkDictionary[link[1]] = link[0]));
 
-        nextUrl = linkDictionary["next"];
+          nextUrl = linkDictionary["next"];
+        }
 
         return response.json();
       })

--- a/canvas-mods/shared-locations/users/feature-enhance-accounts-list/enhance-accounts-list-user.js
+++ b/canvas-mods/shared-locations/users/feature-enhance-accounts-list/enhance-accounts-list-user.js
@@ -36,7 +36,7 @@
       const accountNumber = item.querySelector("a").href.split("/").pop();
       const baseUrl = `${window.location.protocol}//${window.location.hostname}`;
       const url = `${baseUrl}/api/v1/accounts/${accountNumber}/admins?user_id[]=${userId}`; // TODO Update to be paginated
-      fetch(url)
+      fetch(url, { headers: { Accept: "application/json" } })
         .then(response => response.json())
         .then(data => {
           let adminRoleDetails = "";

--- a/canvas-mods/shared-locations/users/feature-enhance-courses-list/enhance-courses-list-user.js
+++ b/canvas-mods/shared-locations/users/feature-enhance-courses-list/enhance-courses-list-user.js
@@ -557,7 +557,7 @@
               .replace("courses", "")
               .replaceAll("/", "");
             const baseUrl = `${window.location.protocol}//${window.location.hostname}`;
-            fetch(`${baseUrl}/api/v1/courses/${canvasCourseCode}`)
+            fetch(`${baseUrl}/api/v1/courses/${canvasCourseCode}`, { headers: { Accept: "application/json" } })
               .then((response) => response.json())
               .then((data) => {
                 const courseCode = data?.course_code;

--- a/canvas-mods/users/grades/feature-update-user-info-on-grades/update-user-info-on-grades.js
+++ b/canvas-mods/users/grades/feature-update-user-info-on-grades/update-user-info-on-grades.js
@@ -72,7 +72,7 @@
 
     const fetches = [];
     fetches.push(
-      fetch(url)
+      fetch(url, { headers: { Accept: "application/json" } })
         .then((response) => response.json())
         .then((data) => {
           user = data;

--- a/utils/common/ski-canvas-lms-api-calls.js
+++ b/utils/common/ski-canvas-lms-api-calls.js
@@ -40,7 +40,7 @@ class SkiCanvasLmsApiCaller {
     }
 
     let requestResponse;
-    return await fetch(requestUrl)
+    return await fetch(requestUrl, { headers: { Accept: "application/json" } })
       .then((response) => {
         requestResponse = response;
         return response.json();


### PR DESCRIPTION
## Problem

Several feature scripts call `fetch(url)` without an `Accept` header. When the header is absent, Canvas prepends its anti-JSON-hijacking `while(1);` prefix to the response body, so `response.json()` throws:

```
SyntaxError: Unexpected token 'w', "while(1);{"... is not valid JSON
```

This is especially visible on installs using a **custom Canvas domain** (not `*.instructure.com`). Symptoms I hit included the global-nav **admin quick-access flyout** (empty account dropdown, plus a `GET /api/v1/accounts//permissions 404` and a `Cannot read properties of null (reading 'replaceAll')` from the pagination `Link` header) and the **SIS import log** failing to load.

## Fix

Add `Accept: application/json` to the remaining `fetch` calls — matching the header already set in the main `SkiCanvasLmsApiCall` request path (`utils/common/ski-canvas-lms-api-calls.js`) — so Canvas returns clean JSON. Also guard the paginated `Link` header against `null` so a single-page (non-paginated) response doesn't throw on `replaceAll`, and default the flyout's `getPermissions` to `self` when no account is selected.

Files touched:
- `canvas-mods/accounts/home-courses-search/feature-enhance-search-results/enhance-search-results-courses.js`
- `canvas-mods/accounts/sis_import/feature-sis-import-log/sis-import-log.js` (+ null `Link` guard)
- `canvas-mods/accounts/sub_accounts/feature-show-ids/show-ids-sub-accounts.js`
- `canvas-mods/shared-locations/global/feature-admin-quick-access/feature-admin-quick-access-global-nav.js` (+ null `Link` guard, default account to `self`)
- `canvas-mods/shared-locations/users/feature-enhance-accounts-list/enhance-accounts-list-user.js`
- `canvas-mods/shared-locations/users/feature-enhance-courses-list/enhance-courses-list-user.js`
- `canvas-mods/users/grades/feature-update-user-info-on-grades/update-user-info-on-grades.js`
- `utils/common/ski-canvas-lms-api-calls.js` (simple GET path)

## Testing

Running an unpacked build on a live Canvas instance with a custom domain: the admin quick-access flyout now populates and the SIS import log loads, with the `while(1);` / `replaceAll` / `accounts//permissions` errors gone. Change is limited to adding the request header and null-guarding existing pagination logic; no behavioural change on `*.instructure.com` where these calls already worked.

Thanks for maintaining this — it's genuinely useful for our admin team. Happy to adjust the approach (e.g. route everything through the shared helper) if you'd prefer.